### PR TITLE
fix: add missing instance_resource 

### DIFF
--- a/examples/complete_linux/main.tf
+++ b/examples/complete_linux/main.tf
@@ -22,6 +22,7 @@ module "resource_names" {
   class_env               = var.class_env
   cloud_resource_type     = each.value.name
   instance_env            = var.instance_env
+  instance_resource       = var.instance_resource
   maximum_length          = each.value.max_length
 }
 

--- a/examples/complete_windows/main.tf
+++ b/examples/complete_windows/main.tf
@@ -22,6 +22,7 @@ module "resource_names" {
   class_env               = var.class_env
   cloud_resource_type     = each.value.name
   instance_env            = var.instance_env
+  instance_resource       = var.instance_resource
   maximum_length          = each.value.max_length
 }
 


### PR DESCRIPTION
Fixes TFLint warning for unused variable `instance_resource` in complete_linux and complete_windows examples by passing it to the resource_names module.